### PR TITLE
Update IdealImageWithDefaults to remove use of .defaultProps

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -81,6 +81,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "AndrewSepic",
+      "name": "Andrew Sepic",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1304666?v=4",
+      "profile": "https://github.com/AndrewSepic",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "repoType": "github"

--- a/src/components/IdealImageWithDefaults/index.js
+++ b/src/components/IdealImageWithDefaults/index.js
@@ -1,17 +1,14 @@
-import React from 'react'
-import IdealImage from '../IdealImage'
-import icons from '../icons'
-import theme from '../theme'
+import React from 'react';
+import IdealImage from '../IdealImage';
+import icons from '../icons';
+import theme from '../theme';
 
-const IdealImageWithDefaults = props => <IdealImage {...props} />
+const IdealImageWithDefaults = ({
+  icons: iconsProp = icons,
+  theme: themeProp = theme,
+  ...props
+}) => <IdealImage {...props} icons={iconsProp} theme={themeProp} />;
 
-IdealImageWithDefaults.defaultProps = {
-  ...IdealImage.defaultProps,
-  icons,
-  theme,
-}
+IdealImageWithDefaults.propTypes = IdealImage.propTypes;
 
-// eslint-disable-next-line react/forbid-foreign-prop-types
-IdealImageWithDefaults.propTypes = IdealImage.propTypes
-
-export default IdealImageWithDefaults
+export default IdealImageWithDefaults;

--- a/src/components/IdealImageWithDefaults/index.js
+++ b/src/components/IdealImageWithDefaults/index.js
@@ -1,7 +1,7 @@
-import React from 'react';
-import IdealImage from '../IdealImage';
-import icons from '../icons';
-import theme from '../theme';
+import React from 'react'
+import IdealImage from '../IdealImage'
+import icons from '../icons'
+import theme from '../theme'
 
 const IdealImageWithDefaults = ({
   icons: iconsProp = icons,
@@ -9,6 +9,6 @@ const IdealImageWithDefaults = ({
   ...props
 }) => <IdealImage {...props} icons={iconsProp} theme={themeProp} />;
 
-IdealImageWithDefaults.propTypes = IdealImage.propTypes;
+IdealImageWithDefaults.propTypes = IdealImage.propTypes
 
-export default IdealImageWithDefaults;
+export default IdealImageWithDefaults


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:
This PR changes the use of default Props in the functional component to match the object deconstruction method which is supported in future version of react. 

**Why**:
The use of .defaultProps creates a noisy console warning on a brand new docusaurus (3.6.3) site that uses Plugin Ideal Image.   Updating this file to match coming changes in react removes this warning.
<img width="1434" alt="Screenshot 2024-12-16 at 11 29 41 AM" src="https://github.com/user-attachments/assets/071870aa-6be7-4789-9973-4d3910a1f667" />
<!-- How were these changes implemented? -->

**How**:
Updated the `IdealImageWithDefaults.js` file.
<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation - none needed
* [ ] Tests (kcd scripts is failing on `npm run test`
* [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
